### PR TITLE
0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ the `Success<T>` alone.
 - Added the ability to invoke `err` with a string type,
 resulting in a `Result<T, Error>`
 
+## [0.4.0]
+
+- Added a default export to both result and option
+- Added ability to call result.err with no parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ resulting in a `Result<T, Error>`
 
 - Added a default export to both result and option
 - Added ability to call result.err with no parameters
+- Added utility function `fromPromise`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dbidwell04/ts-utils",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dbidwell04/ts-utils",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbidwell94/ts-utils",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A collection of helpful TypeScript utilities with the aim of having limited production dependencies.",
   "main": "index.js",
   "repository": {

--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -169,3 +169,9 @@ export function none<T>(): Option<T> {
 export function some<T>(value: T): Option<T> {
   return buildOption({ value, _marker: MarkerType.Some });
 }
+
+export default {
+  some,
+  none,
+  fromSerializableOption
+}

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -1,32 +1,32 @@
-import { fromSerializableOption, none, OptionIsEmptyError, some } from ".";
+import option, { OptionIsEmptyError } from ".";
 
 describe("src/utility/option.ts", () => {
   it("Constructs an Option<T> type with a provided value", () => {
-    const optionValue = some(1);
+    const optionValue = option.some(1);
 
     expect(optionValue.isSome()).toBeTruthy();
   });
 
   it("Constructs an Option<T> with no provided value", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(optionValue.isNone()).toBeTruthy();
   });
 
   it("Throws an error on unwrap() if the Option<T> is empty", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(() => optionValue.unwrap()).toThrow(OptionIsEmptyError);
   });
 
   it("Provdes a default value on unwrapOrDefault() if the Option<T> is empty", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(optionValue.unwrapOr(3)).toEqual(3);
   });
 
   it("Throws an error if the argument for unwrapOr() is undefined or null", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(() => optionValue.unwrapOr(null as never)).toThrow(
       OptionIsEmptyError
@@ -34,43 +34,43 @@ describe("src/utility/option.ts", () => {
   });
 
   it("Returns the contained value when unwrap() is called with a value value in the Option<T>", () => {
-    const optionValue = some(3);
+    const optionValue = option.some(3);
 
     expect(optionValue.unwrap()).toEqual(3);
   });
 
   it("Returns the contained value when unwrapOrDefault() is called with a valid value in the Option<T>", () => {
-    const optionValue = some(3);
+    const optionValue = option.some(3);
 
     expect(optionValue.unwrapOr(2)).toEqual(3);
   });
 
   it("Allows direct access of the value if the Option<T> is a Some<T>", () => {
-    const optionValue = some(3);
+    const optionValue = option.some(3);
 
     expect(optionValue).toHaveProperty("value");
   });
 
   it("Does not have the value property if the Option<T> is a None", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(optionValue).not.toHaveProperty("value");
   });
 
   it("Transforms the Option<T> into a Result Failure<E> when calling okOr() on a None type", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(optionValue.okOr(new Error()).isError()).toBeTruthy();
   });
 
   it("Transforms the Option<T> into a Result Success<T> with calling okOr() on a Some<T> type", () => {
-    const optionValue = some(2);
+    const optionValue = option.some(2);
 
     expect(optionValue.okOr(new Error()).isOk()).toBeTruthy();
   });
 
   it("Throws an error using the provided message when calling expect() on a None type", () => {
-    const optionValue = none();
+    const optionValue = option.none();
 
     expect(() => optionValue.expect("This is an error")).toThrow(
       "This is an error"
@@ -78,32 +78,32 @@ describe("src/utility/option.ts", () => {
   });
 
   it("Doesn't throw an error when calling expect() on a Some<T> type", () => {
-    const optionValue = some(2);
+    const optionValue = option.some(2);
 
     expect(() => optionValue.expect("This is an error")).not.toThrow();
   });
 
   it("Returns a None type if map() is called on an existing None type", () => {
-    const optionValue = none<number>();
+    const optionValue = option.none<number>();
 
     expect(optionValue.map((value) => value + 1).isNone()).toBeTruthy();
   });
 
   it("Returns a Some<T> if map() is called on a Some<T> type, having applied the mapped function to the inner type", () => {
-    const optionValue = some(1);
+    const optionValue = option.some(1);
 
     expect(optionValue.map((value) => value + 1).unwrap()).toEqual(2);
   });
 
   it("Creates a serializable Option<T> when serialize() is called on an Option<T> type", () => {
-    const optionValue = some(1);
+    const optionValue = option.some(1);
 
     expect(optionValue.serialize()).toEqual({
       _marker: 0,
       value: 1,
     });
 
-    const noneOptionValue = none();
+    const noneOptionValue = option.none();
 
     expect(noneOptionValue.serialize()).toEqual({
       _marker: 1,
@@ -111,12 +111,12 @@ describe("src/utility/option.ts", () => {
   });
 
   it("Converts a SerializableOption<T> back into an Option<T> when calling fromSerializableOption()", () => {
-    const serializable = some(1).serialize();
+    const serializable = option.some(1).serialize();
 
-    expect(fromSerializableOption(serializable).isSome()).toBeTruthy();
+    expect(option.fromSerializableOption(serializable).isSome()).toBeTruthy();
 
-    const noneSerializable = none().serialize();
+    const noneSerializable = option.none().serialize();
 
-    expect(fromSerializableOption(noneSerializable).isNone()).toBeTruthy();
+    expect(option.fromSerializableOption(noneSerializable).isNone()).toBeTruthy();
   });
 });

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -177,3 +177,8 @@ export function ok<T, E extends Error = Error>(value: T): Result<T, E> {
 
   return buildResult(innerType, MarkerType.Success);
 }
+
+export default {
+  err,
+  ok
+}

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -1,6 +1,18 @@
 import { none, Option, some } from "../option";
 
 /**
+ * Represents an unknown error type that is not an instance of `Error`
+ * Useful when you are catching an error in try/catch but the error is not an instance of `Error`
+ */
+export class UnknownError extends Error {
+  unknownError: any;
+  constructor(unknownError: any) {
+    super();
+    this.unknownError = unknownError;
+  }
+}
+
+/**
  * Represents the two possible inner types of a `Result<T, E>`
  */
 enum MarkerType {
@@ -157,16 +169,22 @@ export function err<T, E extends Error = Error>(error: E): Result<T, E>;
  * @param error The error to wrap in the `Result<T, E>`
  * @returns A `Result<T, E>` type with a `Failure<E>` inner type
  */
-export function err<T, E extends Error = Error>(error?: E | string): Result<T, E> {
+export function err<T, E extends Error = Error>(
+  error?: E | string
+): Result<T, E> {
   if (!error) {
-    return buildResult({ error: new Error() } as Failure<E>, MarkerType.Failure);
-  }
-  else if (typeof error === "string") {
-    return buildResult({ error: new Error(error) } as Failure<E>, MarkerType.Failure);
+    return buildResult(
+      { error: new Error() } as Failure<E>,
+      MarkerType.Failure
+    );
+  } else if (typeof error === "string") {
+    return buildResult(
+      { error: new Error(error) } as Failure<E>,
+      MarkerType.Failure
+    );
   } else {
     return buildResult({ error } as Failure<E>, MarkerType.Failure);
   }
-
 }
 
 /**
@@ -182,7 +200,27 @@ export function ok<T, E extends Error = Error>(value: T): Result<T, E> {
   return buildResult(innerType, MarkerType.Success);
 }
 
+/**
+ * Constructs a `Result<T, E>` type from a `Promise<T>`. The `Result<T, E>` will be a `Success<T>` if the `Promise<T>` resolves, otherwise a `Failure<E>` if the `Promise<T>` rejects.
+ * @param promise The `Promise<T>` to convert to a `Result<T, E>`
+ * @returns A `Result<T, E>` type with a `Success<T>` inner type if the `Promise<T>` resolves, otherwise a `Failure<E>` inner type if the `Promise<T>` rejects
+ */
+export async function fromPromise<T>(
+  promise: Promise<T>
+): Promise<Result<T, Error>> {
+  try {
+    const value = await promise;
+    return ok(value);
+  } catch (error) {
+    if (error instanceof Error) {
+      return err(error);
+    }
+    return err(new UnknownError(error));
+  }
+}
+
 export default {
   err,
-  ok
-}
+  ok,
+  fromPromise,
+};

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -149,6 +149,7 @@ function buildResult<T, E extends Error>(
   };
 }
 
+export function err<T>(): Result<T, Error>;
 export function err<T>(error: string): Result<T, Error>;
 export function err<T, E extends Error = Error>(error: E): Result<T, E>;
 /**
@@ -156,8 +157,11 @@ export function err<T, E extends Error = Error>(error: E): Result<T, E>;
  * @param error The error to wrap in the `Result<T, E>`
  * @returns A `Result<T, E>` type with a `Failure<E>` inner type
  */
-export function err<T, E extends Error = Error>(error: E | string): Result<T, E> {
-  if (typeof error === "string") {
+export function err<T, E extends Error = Error>(error?: E | string): Result<T, E> {
+  if (!error) {
+    return buildResult({ error: new Error() } as Failure<E>, MarkerType.Failure);
+  }
+  else if (typeof error === "string") {
     return buildResult({ error: new Error(error) } as Failure<E>, MarkerType.Failure);
   } else {
     return buildResult({ error } as Failure<E>, MarkerType.Failure);

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -111,4 +111,10 @@ describe("src/utility/result.ts", () => {
 
     expect(() => resultValue.unwrap()).toThrow(Error);
   })
+
+  it("Constructs a Failure<E> error with an Error with no message if err() is called with no parameters", () => {
+    const resultValue = result.err();
+
+    expect(() => resultValue.unwrap()).toThrow(Error);
+  })
 });

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -1,4 +1,4 @@
-import result from ".";
+import result, { UnknownError } from ".";
 
 class NewErrorClass extends Error {
   constructor() {
@@ -110,11 +110,31 @@ describe("src/utility/result.ts", () => {
     const resultValue = result.err("This is an error");
 
     expect(() => resultValue.unwrap()).toThrow(Error);
-  })
+  });
 
   it("Constructs a Failure<E> error with an Error with no message if err() is called with no parameters", () => {
     const resultValue = result.err();
 
     expect(() => resultValue.unwrap()).toThrow(Error);
-  })
+  });
+
+  it("Constructs a Result<T> from a promise when calling fromPromise() with a promise that resolves", async () => {
+    const resultValue = await result.fromPromise(Promise.resolve(3));
+
+    expect(resultValue.unwrap()).toEqual(3);
+  });
+
+  it("Constructs a Result<T> from a promise when calling fromPromise() with a promise that rejects", async () => {
+    const resultValue = await result.fromPromise(
+      Promise.reject(new NewErrorClass())
+    );
+
+    expect(() => resultValue.unwrap()).toThrow(NewErrorClass);
+  });
+
+  it("Constructs a Result<T> from a promise that throws something other than an Error", async () => {
+    const resultValue = await result.fromPromise(Promise.reject(2));
+
+    expect(() => resultValue.unwrap()).toThrow(UnknownError);
+  });
 });

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -1,4 +1,4 @@
-import { err, ok } from ".";
+import result from ".";
 
 class NewErrorClass extends Error {
   constructor() {
@@ -7,43 +7,43 @@ class NewErrorClass extends Error {
 }
 describe("src/utility/result.ts", () => {
   it("Calling unwrap() on a Success<T> provides the Success<T> value", () => {
-    const resultValue = ok(1);
+    const resultValue = result.ok(1);
 
     expect(resultValue.unwrap()).toEqual(1);
   });
 
   it("Calling unwrap() on a Failure<E> provides the Failure<E> error", () => {
-    const resultValue = err(new NewErrorClass());
+    const resultValue = result.err(new NewErrorClass());
 
     expect(() => resultValue.unwrap()).toThrow(NewErrorClass);
   });
 
   it("Returns if the Result<T, E> is a Success<T>", () => {
-    const resultValue = ok(3);
+    const resultValue = result.ok(3);
 
     expect(resultValue.isOk()).toBeTruthy();
   });
 
   it("Returns if the Result<T, E> is a Failure<E>", () => {
-    const resultValue = err(new Error());
+    const resultValue = result.err(new Error());
 
     expect(resultValue.isError()).toBeTruthy();
   });
 
   it("Provides a defaultValue when unwrapOr() is called on a Failure<E> type", () => {
-    const resultValue = err(new Error());
+    const resultValue = result.err(new Error());
 
     expect(resultValue.unwrapOr(2)).toEqual(2);
   });
 
   it("Provides the Success<T> value if unwrapOr() is called on a Success<T> type", () => {
-    const resultValue = ok(2);
+    const resultValue = result.ok(2);
 
     expect(resultValue.unwrapOr(5)).toEqual(2);
   });
 
   it("Throws the supplied Error if unwrapOrElse() is called on a Failure<E> type", () => {
-    const resultValue = err(new Error());
+    const resultValue = result.err(new Error());
 
     expect(() => resultValue.unwrapOrElse(new NewErrorClass())).toThrow(
       NewErrorClass
@@ -51,49 +51,49 @@ describe("src/utility/result.ts", () => {
   });
 
   it("Provides the Success<T> value if unwrapOrElse() is called on a Success<T> type", () => {
-    const resultValue = ok(3);
+    const resultValue = result.ok(3);
 
     expect(resultValue.unwrapOrElse(new NewErrorClass())).toEqual(3);
   });
 
   it("Converts the Success<T> to an Option<T> if ok() is called on a Success<T> type", () => {
-    const resultValue = ok(3);
+    const resultValue = result.ok(3);
 
     expect(resultValue.ok().isSome()).toBeTruthy();
   });
 
   it("Converts the Failure<E> to an Option<T> if ok() is called on a Failure<E> type", () => {
-    const resultValue = err(new Error());
+    const resultValue = result.err(new Error());
 
     expect(resultValue.ok().isNone()).toBeTruthy();
   });
 
   it("Converts the Success<T> to an Option<E> if err() is called on a Success<T> type", () => {
-    const resultValue = ok(2);
+    const resultValue = result.ok(2);
 
     expect(resultValue.err().isNone()).toBeTruthy();
   });
 
   it("Converts the Failure<E> to an Option<E> if err() is called on a Failure<E> type", () => {
-    const resultValue = err(new Error());
+    const resultValue = result.err(new Error());
 
     expect(resultValue.err().isSome()).toBeTruthy();
   });
 
   it("Maps the Success<T> value to a new value if mapOk() is called on a Success<T> type", () => {
-    const resultValue = ok(2);
+    const resultValue = result.ok(2);
 
     expect(resultValue.mapOk((x) => x.toString()).unwrap()).toEqual("2");
   });
 
   it("Does not map the Success<T> value if mapOk() is called on a Failure<E> type", () => {
-    const resultValue = err<number>(new Error());
+    const resultValue = result.err<number>(new Error());
 
     expect(resultValue.mapOk((x) => x * 2).isError()).toBeTruthy();
   });
 
   it("Maps the Failure<E> error to a new error if mapErr() is called on a Failure<E> type", () => {
-    const resultValue = err(new Error());
+    const resultValue = result.err(new Error());
 
     expect(
       resultValue.mapErr(() => new NewErrorClass()).isError()
@@ -101,13 +101,13 @@ describe("src/utility/result.ts", () => {
   });
 
   it("Does not map the Failure<E> error if mapErr() is called on a Success<T> type", () => {
-    const resultValue = ok(2);
+    const resultValue = result.ok(2);
 
     expect(resultValue.mapErr(() => new NewErrorClass()).isOk()).toBeTruthy();
   });
 
   it("Constructs a Failire<E> error with a default Error if provided with a string instead of an Error", () => {
-    const resultValue = err("This is an error");
+    const resultValue = result.err("This is an error");
 
     expect(() => resultValue.unwrap()).toThrow(Error);
   })


### PR DESCRIPTION
- Adds a default export to option and result files
- Adds ability to call result.err with no parameters, resulting in the creation of a default Error class with no message on a Failure<E> type