### PR TITLE
From serializable option optional option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,10 @@
   - Option exported as `import { option } from '@dbidwell94/ts-utils'`
   - Result exported as `import { result } from '@dbidwell94/ts-utils'`
 - Added documentation around the named result and option export namespaces
+
+## [0.5.0]
+
+- Changed function signature of `fromSerializableOption` to accept a possibly undefined object
+  - If undefined is provided, a `None` type is returned.
+- Changed conditional for `fromSerializableOption` to be more resilient with
+  possibly bad types passed as a parameter

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dbidwell04/ts-utils",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dbidwell04/ts-utils",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbidwell94/ts-utils",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A collection of helpful TypeScript utilities with the aim of having limited production dependencies.",
   "main": "dist/index.js",
   "files": [

--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -144,12 +144,12 @@ function buildOption<T>(innerType: Some<T> | None): Option<T> {
  * @returns An Option<T> with all the data from the SerializableOption<T> plus the utility functions
  */
 export function fromSerializableOption<T>(
-  option: SerializableOption<T>
+  option?: SerializableOption<T>
 ): Option<T> {
-  if (option._marker === MarkerType.None) {
-    return none();
-  } else {
+  if (option && option._marker === MarkerType.Some) {
     return some(option.value);
+  } else {
+    return none();
   }
 }
 

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -117,6 +117,23 @@ describe("src/utility/option.ts", () => {
 
     const noneSerializable = option.none().serialize();
 
-    expect(option.fromSerializableOption(noneSerializable).isNone()).toBeTruthy();
+    expect(
+      option.fromSerializableOption(noneSerializable).isNone()
+    ).toBeTruthy();
   });
+
+  it("Returns a None type if `fromSerializableOption()` is called with no object or undefined", () => {
+    const result = option.fromSerializableOption(undefined);
+
+    expect(result.isNone()).toBeTruthy();
+  });
+
+  it.each([[1], [{}], ["testString"], [[]]])(
+    "Returns a None type if `fromSerializableOption()` is called with a non-Option<T> type",
+    (testValue) => {
+      const result = option.fromSerializableOption(testValue as never);
+
+      expect(result.isNone()).toBeTruthy();
+    }
+  );
 });


### PR DESCRIPTION
This pull request includes updates to the `fromSerializableOption` function, version bump, and additional test cases to improve the resilience and functionality of the `fromSerializableOption` function.

### Functionality Updates:
* Changed the function signature of `fromSerializableOption` to accept a possibly undefined object and return a `None` type if undefined is provided. This change makes the function more resilient to bad types passed as parameters (`src/option/index.ts`).

### Version Update:
* Updated the package version from `0.4.1` to `0.5.0` in `package.json` to reflect the new changes.

### Documentation:
* Added a new section in `CHANGELOG.md` to document the changes in version `0.5.0`, including the updated function signature and improved resilience of the `fromSerializableOption` function.

### Testing:
* Added new test cases in `src/option/option.test.ts` to ensure `fromSerializableOption` returns a `None` type when called with no object, undefined, or non-Option types.