### PR TITLE
AndThen? New utility functions and an overload for fromPromise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.0]
+
+- Add new utility function `andThen` for both `Result` and `Option` types
+- Added function overload for `fromPromise` which will convert a `Result<Promise<T>, E>` to a `Promise<Result<T, E>>`
+
 ## [0.5.2]
 
 - Upgrade dev dependencies and fix dev audit issue

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dbidwell94/ts-utils",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dbidwell94/ts-utils",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbidwell94/ts-utils",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "A collection of helpful TypeScript utilities with the aim of having limited production dependencies.",
   "main": "dist/index.js",
   "files": [

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,0 +1,33 @@
+import { option, result, Option, Result } from ".";
+
+describe("Integration tests for result and option types", () => {
+  it.each([
+    [option.some(1), true, 1],
+    [option.none<number>(), false, null],
+  ])(
+    "Can convert an Option<T> to a Result<T, E> with okOr()",
+    (opt, isOk, innerVal) => {
+      const resultValue = opt.okOr("This is an error");
+
+      expect(resultValue.isOk()).toEqual(isOk);
+      if (innerVal) {
+        expect(resultValue.unwrap()).toEqual(innerVal);
+      }
+    }
+  );
+
+  it("Can do a complex map of an Option<T> to a Result<T, Error>", async () => {
+    function addAsync(num: number): Promise<number> {
+      return Promise.resolve(num + 1);
+    }
+
+    const optValue = option.some(123);
+
+    const resultingValue = await result.fromPromise(
+      optValue.okOr("No value").mapOk(addAsync)
+    );
+
+    expect(resultingValue.isOk()).toBeTruthy();
+    expect(resultingValue.unwrap()).toEqual(124);
+  });
+});

--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -78,7 +78,8 @@ interface OptionUtils<T> {
    */
   map<NewT>(mapFn: (option: T) => NewT): Option<NewT>;
   /**
-   * Flat maps the inner value of the Option<T> to a new Option<NewT>
+   * maps the value of this Option<T> to a Option<NewT> using the provided function. This is useful if you wish to chain
+   * multiple Option<T> types together. Flattens the Option<Option<NewT>> to an Option<NewT>
    * @param mapFn The function which will be called if the Option<T> is a Some<T>
    */
   andThen<NewT>(mapFn: (option: T) => Option<NewT>): Option<NewT>;

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -1,4 +1,5 @@
 import { OptionIsEmptyError, option } from ".";
+import { result } from "../result";
 
 describe("src/utility/option.ts", () => {
   it("Constructs an Option<T> type with a provided value", () => {
@@ -69,6 +70,12 @@ describe("src/utility/option.ts", () => {
     expect(optionValue.okOr(new Error()).isOk()).toBeTruthy();
   });
 
+  it("Constructs a base Error class if okOr() is called with a string type", () => {
+    const optionValue = option.none();
+
+    expect(optionValue.okOr("This is an error").isError()).toBeTruthy();
+  })
+
   it("Throws an error using the provided message when calling expect() on a None type", () => {
     const optionValue = option.none();
 
@@ -136,4 +143,12 @@ describe("src/utility/option.ts", () => {
       expect(result.isNone()).toBeTruthy();
     }
   );
+
+  it("Performs andThen on a Some<T> type, returning a new Option<NewT>", () => {
+    const optionValue = option.some(1);
+
+    const newOption = optionValue.andThen(val => option.some(val + 1));
+
+    expect(newOption.unwrap()).toEqual(2);
+  });
 });

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -151,4 +151,12 @@ describe("src/utility/option.ts", () => {
 
     expect(newOption.unwrap()).toEqual(2);
   });
+
+  it("Does not perform andThen on a None type, returning a None type", () => {
+    const optionValue = option.none<number>();
+
+    const newOption = optionValue.andThen(val => option.some(val + 1));
+
+    expect(newOption.isNone()).toBeTruthy();
+  });
 });

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -201,21 +201,43 @@ export function ok<T, E extends Error = Error>(value: T): Result<T, E> {
 }
 
 /**
- * Constructs a `Result<T, E>` type from a `Promise<T>`. The `Result<T, E>` will be a `Success<T>` if the `Promise<T>` resolves, otherwise a `Failure<E>` if the `Promise<T>` rejects.
- * @param promise The `Promise<T>` to convert to a `Result<T, E>`
- * @returns A `Result<T, E>` type with a `Success<T>` inner type if the `Promise<T>` resolves, otherwise a `Failure<E>` inner type if the `Promise<T>` rejects
+ * Constructs a `Result<T, E>` type from a `Result<Promise<T>, E>`. The `Result<T, E>` will be a `Success<T>` if the `Promise<T>` resolves,
+ * otherwise a `Failure<E>` if the `Promise<T>` rejects.
+ * @param val The `Result<Promise<T>, E>` to convert to a `Promise<Result<T, E>>`
  */
-export async function fromPromise<T>(
-  promise: Promise<T>
-): Promise<Result<T, Error>> {
+export async function fromPromise<T, E extends Error>(
+  val: Result<Promise<T>, E>
+): Promise<Result<T, E>>;
+/**
+ * Constructs a `Result<T, E>` type from a `Promise<T>`. The `Result<T, E>` will be a `Success<T>` if the `Promise<T>` resolves,
+ * otherwise a `Failure<E>` if the `Promise<T>` rejects.
+ * @param val The `Promise<T>` to convert to a `Promise<Result<T, E>>`
+ */
+export async function fromPromise<T, E extends Error = Error>(
+  val: Promise<T>
+): Promise<Result<T, E>>;
+export async function fromPromise<T, E extends Error = Error>(
+  val: Promise<T> | Result<Promise<T>, E>
+): Promise<Result<T, E | Error>> {
+  let promise: Promise<T>;
+
+  if (!(val instanceof Promise)) {
+    if (val.isError()) {
+      return err(val.error);
+    }
+    promise = val.value;
+  } else {
+    promise = val;
+  }
+
   try {
     const value = await promise;
     return ok(value);
   } catch (error) {
     if (error instanceof Error) {
-      return err(error);
+      return err(error) as Result<T, Error>;
     }
-    return err(new UnknownError(error));
+    return err(new UnknownError(error)) as Result<T, Error>;
   }
 }
 

--- a/src/result/index.ts
+++ b/src/result/index.ts
@@ -88,6 +88,12 @@ interface ResultUtils<T, E extends Error = Error> {
    */
   mapOk<NewT>(fn: (value: T) => NewT): Result<NewT, E>;
   /**
+   * Maps a `Result<T, E>` to `Result<NewT, E>` by applying a function to a contained `Success<T>` value, leaving an `Error<E>` value untouched.
+   * The resulting `Result<NewT, E>` is then flattened to avoid nested Result types.
+   * @param fn - The function to apply to the inner value
+   */
+  andThen<NewT>(fn: (value: T) => Result<NewT, E>): Result<NewT, E>;
+  /**
    * Maps a `Result<T, E>` to `Result<T, NewE>` by applying a function to a contained `Error<E>` value, leaving a `Success<T>` value untouched.
    * @param fn - The function to apply to the inner error
    */
@@ -149,6 +155,12 @@ function buildResult<T, E extends Error>(
     mapOk<NewT>(fn: (value: T) => NewT): Result<NewT, E> {
       if (this.isOk()) {
         return ok(fn(this.value));
+      }
+      return err(this.error);
+    },
+    andThen<NewT>(fn: (value: T) => Result<NewT, E>): Result<NewT, E> {
+      if (this.isOk()) {
+        return fn(this.value);
       }
       return err(this.error);
     },

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -159,4 +159,20 @@ describe("src/utility/result.ts", () => {
 
     expect(finalResult.unwrap()).toEqual(3);
   });
+
+  it("Constructs a Result<T, E> from a Result containing a promise that rejects", async () => {
+    const resultValue = result.ok(Promise.reject(new NewErrorClass()));
+
+    const finalResult = await result.fromPromise(resultValue);
+
+    expect(() => finalResult.unwrap()).toThrow(NewErrorClass);
+  });
+
+  it("Constructs a Result<T, E> from a Result that is of a Failure<E> type", async () => {
+    const resultValue = result.err<Promise<number>>(new Error());
+
+    const finalResult = await result.fromPromise(resultValue);
+
+    expect(finalResult.isError()).toBeTruthy();
+  });
 });

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -92,6 +92,20 @@ describe("src/utility/result.ts", () => {
     expect(resultValue.mapOk((x) => x * 2).isError()).toBeTruthy();
   });
 
+  it("Maps the Success<T> value to a new Result<NewT, E> if andThen() is called on a Success<T> type", () => {
+    const resultValue = result.ok(2);
+
+    expect(
+      resultValue.andThen((x) => result.ok(x.toString())).unwrap()
+    ).toEqual("2");
+  });
+
+  it("Does not map the Success<T> value if andThen() is called on a Failure<E> type", () => {
+    const resultValue = result.err<number>(new Error());
+
+    expect(resultValue.andThen((x) => result.ok(x * 2)).isError()).toBeTruthy();
+  });
+
   it("Maps the Failure<E> error to a new error if mapErr() is called on a Failure<E> type", () => {
     const resultValue = result.err(new Error());
 
@@ -144,5 +158,5 @@ describe("src/utility/result.ts", () => {
     const finalResult = await result.fromPromise(resultValue);
 
     expect(finalResult.unwrap()).toEqual(3);
-  })
+  });
 });

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -137,4 +137,12 @@ describe("src/utility/result.ts", () => {
 
     expect(() => resultValue.unwrap()).toThrow(UnknownError);
   });
+
+  it("Constructs a Result<T, E> from a Result containing a promise that resolves", async () => {
+    const resultValue = result.ok(Promise.resolve(3));
+
+    const finalResult = await result.fromPromise(resultValue);
+
+    expect(finalResult.unwrap()).toEqual(3);
+  })
 });


### PR DESCRIPTION
This pull request introduces several new utility functions and enhancements to the `Option` and `Result` types, updates the version to `0.6.0`, and includes new tests to ensure the correctness of these additions.

### New Utility Functions and Enhancements:

* [`src/option/index.ts`](diffhunk://#diff-9a2dd0ca107610b9a7a8030994444615768bd0a9b37f1515b8257c10df3d9b47R72-R85): Added `andThen` function to chain multiple `Option<T>` types and extended `okOr` to accept both `Error` and `string` types. [[1]](diffhunk://#diff-9a2dd0ca107610b9a7a8030994444615768bd0a9b37f1515b8257c10df3d9b47R72-R85) [[2]](diffhunk://#diff-9a2dd0ca107610b9a7a8030994444615768bd0a9b37f1515b8257c10df3d9b47L120-R131) [[3]](diffhunk://#diff-9a2dd0ca107610b9a7a8030994444615768bd0a9b37f1515b8257c10df3d9b47R140-R145)
* [`src/result/index.ts`](diffhunk://#diff-095dbf86e993fd363aabaa642b8d1a3bf741b2e61150ae8688dc527306472d03R90-R95): Added `andThen` function to map a `Result<T, E>` to `Result<NewT, E>` and updated `fromPromise` to handle `Result<Promise<T>, E>`. [[1]](diffhunk://#diff-095dbf86e993fd363aabaa642b8d1a3bf741b2e61150ae8688dc527306472d03R90-R95) [[2]](diffhunk://#diff-095dbf86e993fd363aabaa642b8d1a3bf741b2e61150ae8688dc527306472d03R161-R166) [[3]](diffhunk://#diff-095dbf86e993fd363aabaa642b8d1a3bf741b2e61150ae8688dc527306472d03L204-R252)

### Version Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.5.2` to `0.6.0`.

### Changelog Update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): Documented the new utility functions and version update.

### New Tests:

* [`src/integration.test.ts`](diffhunk://#diff-0c62bdc41b67f03431417635613235b0afb9e4764957a1a5305174d6d87f6583R1-R33): Added integration tests for the `Option` and `Result` types.
* [`src/option/option.test.ts`](diffhunk://#diff-754083253425d4c481d60f81bffc0a5f0edd913fa46142b7eec8d36bf7c269f5R2): Added tests for the new `andThen` function and the extended `okOr` function. [[1]](diffhunk://#diff-754083253425d4c481d60f81bffc0a5f0edd913fa46142b7eec8d36bf7c269f5R2) [[2]](diffhunk://#diff-754083253425d4c481d60f81bffc0a5f0edd913fa46142b7eec8d36bf7c269f5R73-R78) [[3]](diffhunk://#diff-754083253425d4c481d60f81bffc0a5f0edd913fa46142b7eec8d36bf7c269f5R146-R153)
* [`src/result/result.test.ts`](diffhunk://#diff-9f75dacd10f3bceda31bde70fd93b87e966deb00f07730ec0080efa8db707af1R95-R108): Added tests for the new `andThen` function and the updated `fromPromise` function. [[1]](diffhunk://#diff-9f75dacd10f3bceda31bde70fd93b87e966deb00f07730ec0080efa8db707af1R95-R108) [[2]](diffhunk://#diff-9f75dacd10f3bceda31bde70fd93b87e966deb00f07730ec0080efa8db707af1R154-R161)