### PR TITLE
Unsafe option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.1.0]
+
+- Added new unsafe functions to the `Option` type to return unchecked values.
+  - unsafeUnwrap() -- Returns the inner value regardless on if it is `undefined`
+    or `null`
+  - unsafeUnwrapOr() -- Maps the inner value to an optional default value
+    without checking the default value for `null | undefined`
+
 ## [1.0.0]
 
 - Removed multiple named exports from the base library in favor of

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dbidwell94/ts-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dbidwell94/ts-utils",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dbidwell94/ts-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A collection of helpful TypeScript utilities with the aim of having limited production dependencies.",
   "main": "dist/index.js",
   "files": [

--- a/src/option/index.ts
+++ b/src/option/index.ts
@@ -52,12 +52,24 @@ export interface OptionUtils<T> {
    */
   unwrap(): T;
   /**
+   * Extracts the base value from this type, not checking if the value is `None`.
+   * @returns The raw unchecked inner value of the `Option<T>`
+   */
+  unsafeUnwrap(): T | null | undefined;
+  /**
    * Extracts the base value from this type. If there is no value in the `Option<T>`, the function will return the provided default value.
    * @param defaultValue The value to return if the `Option<T>` is a `None`.
    * @throws {OptionIsEmptyError} if the default value is `null` or `undefined`.
    * @returns The value of the `Option<T>` if it is a `Some<T>`, otherwise the default value.
    */
   unwrapOr(defaultValue: T): T;
+  /**
+   * Extracts the base value from this type. If there is no value in the `Option<T>`, the function will return whatever you provided as the
+   * default value, even if that value was not provided (undefined).
+   * @param defaultValue The value to return if the `Option<T>` is a `None`
+   * @returns The possibly undefined | null value of the `Option<T>`.
+   */
+  unsafeUnwrapOr(defaultValue?: T | null): T | null | undefined;
   /**
    * Extracts the base value from this type. The function throws an error with the provided message if there is no value provided.
    * @throws {OptionIsEmptyError} if the default value is `null` or `undefined`.
@@ -114,6 +126,10 @@ function buildOption<T>(innerType: Some<T> | None): Option<T> {
       if (this.isNone()) throw new OptionIsEmptyError();
       return this.value;
     },
+    unsafeUnwrap() {
+      if (this.isNone()) return undefined;
+      return this.value;
+    },
     unwrapOr(defaultValue) {
       if (this.isSome()) return this.value;
       if (defaultValue === null || defaultValue === undefined)
@@ -121,6 +137,10 @@ function buildOption<T>(innerType: Some<T> | None): Option<T> {
           "The provided default value was null or undefined.",
         );
       return defaultValue;
+    },
+    unsafeUnwrapOr(defaultValue) {
+      if (this.isNone()) return defaultValue;
+      return this.value;
     },
     expect(message) {
       if (this.isSome()) return this.value;

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -192,9 +192,21 @@ describe("src/utility/option.ts", () => {
     expect(opt.unsafeUnwrap()).toEqual(undefined);
   });
 
+  it("Returns the inner value of Some<T> if unsafeUnwrap was called on a Some type", () => {
+    const opt = option.some(123);
+
+    expect(opt.unsafeUnwrap()).toEqual(123);
+  });
+
   it("returns the raw default value if unsafeUnwrapOr() was called on a None type", () => {
     const opt = option.unknown(undefined);
 
     expect(opt.unsafeUnwrapOr(null)).toEqual(null);
+  });
+
+  it("Returns the inner value of Some<T> if unsafeUnwrapOr() was called on a Some<T> type", () => {
+    const opt = option.some(123);
+
+    expect(opt.unsafeUnwrapOr(null)).toEqual(123);
   });
 });

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -185,4 +185,16 @@ describe("src/utility/option.ts", () => {
   ])("Properly checks the return type of %s", (_, optVal, validator) => {
     expect(validator(optVal)).toBeTruthy();
   });
+
+  it("Returns `undefined` if unsafeUnwrap() was called on a None type", () => {
+    const opt = option.unknown(undefined);
+
+    expect(opt.unsafeUnwrap()).toEqual(undefined);
+  });
+
+  it("returns the raw default value if unsafeUnwrapOr() was called on a None type", () => {
+    const opt = option.unknown(undefined);
+
+    expect(opt.unsafeUnwrapOr(null)).toEqual(null);
+  });
 });


### PR DESCRIPTION
this PR adds support for unwrapping the `Option` type without checking for `undefined | null`. This also adds support for unwrapOr to return `undefined | null`.

New functions:
  - `unsafeUnwrap(): T | undefined | null`
  - `unsafeUnwrapOr(defaultValue?: T | null): T | undefined | null`